### PR TITLE
build: add PyPI/Zenodo release infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check version consistency across pyproject.toml, .zenodo.json, CITATION.cff
+        run: |
+          python - <<'EOF'
+          import tomllib, json, sys
+          with open("pyproject.toml", "rb") as f:
+              pkg = tomllib.load(f)["project"]["version"]
+          with open(".zenodo.json") as f:
+              zen = json.load(f)["version"]
+          with open("CITATION.cff") as f:
+              cff = next(l.split(":")[1].strip().strip('"') for l in f if l.startswith("version:"))
+          if pkg == zen == cff:
+              print(f"OK: all files at {pkg}")
+          else:
+              print(f"MISMATCH: pyproject.toml={pkg}  .zenodo.json={zen}  CITATION.cff={cff}")
+              sys.exit(1)
+          EOF
+
+  test:
+    needs: version-check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install (core + dev)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Lint
+        run: ruff check preorder4mlc tests
+      - name: Test
+        run: pytest tests/ -q

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,88 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  version-check:
+    name: Check version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check pyproject.toml, .zenodo.json, CITATION.cff match (and match tag if pushed)
+        run: |
+          python - <<'EOF'
+          import tomllib, json, sys, os
+          with open("pyproject.toml", "rb") as f:
+              pkg = tomllib.load(f)["project"]["version"]
+          with open(".zenodo.json") as f:
+              zen = json.load(f)["version"]
+          with open("CITATION.cff") as f:
+              cff = next(l.split(":")[1].strip().strip('"') for l in f if l.startswith("version:"))
+          errors = []
+          if not (pkg == zen == cff):
+              errors.append(f"version mismatch: pyproject.toml={pkg}  .zenodo.json={zen}  CITATION.cff={cff}")
+          ref = os.environ.get("GITHUB_REF", "")
+          if ref.startswith("refs/tags/v"):
+              tag = ref.removeprefix("refs/tags/v")
+              if tag != pkg:
+                  errors.append(f"tag v{tag} does not match pyproject.toml version {pkg}")
+          if errors:
+              for e in errors:
+                  print("ERROR:", e)
+              sys.exit(1)
+          print(f"OK: all files at {pkg}" + (" (tag matches)" if ref.startswith("refs/tags/") else ""))
+          EOF
+
+  build:
+    name: Build distributions
+    needs: version-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write  # OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,31 @@
+{
+  "title": "preorder4mlc: Robust multi-label classification via preference learning",
+  "version": "1.0.0",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "MIT",
+  "description": "<p>preorder4mlc is a Python package that casts multi-label classification (MLC) as order-structure learning. It transforms an MLC problem into a preference-learning task, trains pairwise classifiers, and predicts Bayes-optimal (pre)order structures via integer linear programming. It targets robust MLC under noisy and imbalanced labels and MLC with partial abstention.</p><p>This release accompanies the article <em>\"Robust multi-label classification via preference learning\"</em> (Machine Learning, Springer, 2026).</p>",
+  "creators": [
+    { "name": "Hoang, Xuan-Truong", "orcid": "0009-0003-4350-5148" },
+    { "name": "Nguyen, Vu-Linh" },
+    { "name": "Destercke, Sébastien" },
+    { "name": "de Campos, Cassio" },
+    { "name": "Huynh, Van-Nam" }
+  ],
+  "keywords": [
+    "multi-label classification",
+    "preference learning",
+    "order structures",
+    "integer linear programming",
+    "partial abstention",
+    "robustness"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/hxtruong6/pre-order-for-mlc",
+      "relation": "isSupplementTo",
+      "resource_type": "software",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-05-15
+
+First public release accompanying the paper *"Robust multi-label classification via
+preference learning"* (Machine Learning, Springer, 2026).
+
+### Added
+- Order-structure formulation of MLC: pairwise preference classifiers
+  (`base_classifiers.py`), inference models (`inference_models.py`), and ILP-based
+  search (`searching_algorithms.py`, `solvers.py`) using HiGHS / CVXOPT.
+- Bayes-optimal (pre)order prediction with support for partial abstention and a
+  cost-sensitive layer (`cost_sensitive.py`).
+- Evaluation metrics (`evaluation_metric.py`), training orchestrator
+  (`training_orchestrator.py`), and dataset loaders (`datasets4experiments.py`).
+- Command-line training/evaluation drivers under `scripts/` and an end-to-end
+  reproduction driver `run.sh`.
+- Result aggregation, statistical tests, and figure generation under
+  `preorder4mlc/utils/`.
+- Packaging and release infrastructure: PyPI metadata, Zenodo deposition metadata,
+  CI and publish workflows, Docker reproducibility capsule.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,14 +4,15 @@ title: "preorder4MLC: Pre-Order Based Multi-Label Classification"
 message: "If you use this software, please cite the accompanying paper."
 type: software
 authors:
-  - family-names: Nguyen
-    given-names: Vu-Linh
-    email: vu-linh.nguyen@hds.utc.fr
-    affiliation: "Heudiasyc Laboratory, University of Technology of Compiègne, France"
   - family-names: Hoang
     given-names: Xuan-Truong
     email: hxtruong@jaist.ac.jp
     affiliation: "School of Knowledge Science, Japan Advanced Institute of Science and Technology, Japan"
+    orcid: "https://orcid.org/0009-0003-4350-5148"
+  - family-names: Nguyen
+    given-names: Vu-Linh
+    email: vu-linh.nguyen@hds.utc.fr
+    affiliation: "Heudiasyc Laboratory, University of Technology of Compiègne, France"
   - family-names: Destercke
     given-names: Sébastien
     email: sebastien.destercke@hds.utc.fr
@@ -39,10 +40,11 @@ preferred-citation:
   type: article
   title: "Robust Multi-Label Classification via Preference Learning"
   authors:
-    - family-names: Nguyen
-      given-names: Vu-Linh
     - family-names: Hoang
       given-names: Xuan-Truong
+      orcid: "https://orcid.org/0009-0003-4350-5148"
+    - family-names: Nguyen
+      given-names: Vu-Linh
     - family-names: Destercke
       given-names: Sébastien
     - family-names: de Campos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thanks for your interest in preorder4mlc.
+
+## Development setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Before opening a pull request
+
+- `make lint` — ruff must pass.
+- `make test` — the test suite must pass.
+- Keep `pyproject.toml`, `.zenodo.json`, and `CITATION.cff` at the **same version**;
+  CI fails if they diverge.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+
+## Releasing
+
+Releases are cut by tagging `vX.Y.Z` (matching the version in the three files above);
+the `Publish` workflow builds and uploads to PyPI via OIDC trusted publishing.
+See `docs/REPRODUCING.md` for reproducing the paper results.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Reproducibility-capsule image for preorder4mlc.
+# Reproduces the CHD-49 result on CPU.
+FROM python:3.10-slim
+
+ENV PYTHONHASHSEED=0 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential gfortran \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin the core scientific stack first so the package install does not re-resolve.
+COPY requirements-core.txt /app/requirements-core.txt
+RUN pip install -r /app/requirements-core.txt
+
+# Install the package itself without disturbing the pinned dependencies.
+COPY . /app
+RUN pip install --no-deps -e .
+
+# Default reproducible run: CHD-49 -> /results (mount /results to retrieve output).
+CMD ["bash", "scripts/reproduce_capsule.sh", "/results"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE
+include README.md
+include REPRODUCE.md
+include CITATION.cff
+include requirements.txt
+include requirements-core.txt
+recursive-include docs *.md *.yaml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include CITATION.cff
 include requirements.txt
 include requirements-core.txt
 recursive-include docs *.md *.yaml
+prune docs/superpowers

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Convenience targets. Install with: pip install -e ".[dev]"  (add ,viz for figures)
+DOCKER_IMAGE_NAME = preorder4mlc
+
+lint:
+	ruff check preorder4mlc tests
+
+test:
+	python -m pytest tests/ -q
+
+build:
+	python -m build && python -m twine check dist/*
+
+reproduce:
+	bash scripts/reproduce_capsule.sh results/capsule
+
+docker-run:
+	docker build -t $(DOCKER_IMAGE_NAME) .
+	docker run --rm -v "$(PWD)/results:/results" $(DOCKER_IMAGE_NAME)

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,9 @@
+# Conventions
+
+- **Package layout:** flat `preorder4mlc/` package; CLIs live in `scripts/`.
+- **Datasets:** registered in `preorder4mlc/config.py` (`ConfigManager.DATASET_CONFIGS`);
+  loaded by `preorder4mlc/datasets4experiments.py`.
+- **Results:** per-fold CSVs under `results/<run>/`; aggregated by
+  `preorder4mlc/utils/summarize_metrics.py`.
+- **Solvers:** ILP search uses HiGHS (`highspy`) with a CVXOPT fallback (`solvers.py`).
+- **Versioning:** keep `pyproject.toml`, `.zenodo.json`, `CITATION.cff` in lockstep.

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1,0 +1,19 @@
+# Extending preorder4mlc
+
+## Add a dataset
+Register it in `preorder4mlc/config.py` (`ConfigManager.DATASET_CONFIGS`) with its label
+count and file orientation, and ensure `preorder4mlc/datasets4experiments.py` can load its
+ARFF/CSV. Then add its key to the `DATASETS` array in `run.sh`.
+
+## Add a base classifier
+Implement it in `preorder4mlc/base_classifiers.py` following the existing pairwise /
+label-ranking interface (must expose `fit` / `predict`-style methods consumed by
+`training_orchestrator.py`).
+
+## Add an evaluation metric
+Add the metric to `preorder4mlc/evaluation_metric.py`; it is then available to the
+evaluation scripts and the summary tables.
+
+## Change the ILP search
+The search objective and constraints live in `preorder4mlc/searching_algorithms.py` and
+`preorder4mlc/solvers.py` (HiGHS via `highspy`, CVXOPT fallback).

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,23 @@
+# Release checklist (manual — not run by this plan)
+
+Infrastructure is in place; publishing is a deliberate manual action.
+
+## One-time setup
+- [ ] Confirm the PyPI project name `preorder4mlc` is available
+      (https://pypi.org/project/preorder4mlc/). If taken, pick a new name and update
+      `pyproject.toml`, the badges, and `pip install` references.
+- [ ] Create the project on TestPyPI and PyPI (or reserve via first upload).
+- [ ] In the GitHub repo, create two **environments**: `testpypi` and `pypi`.
+- [ ] Configure **OIDC trusted publishing** on PyPI/TestPyPI for this repo + environment
+      (no API tokens stored). See https://docs.pypi.org/trusted-publishers/.
+- [ ] Connect the repo to **Zenodo** (https://zenodo.org/account/settings/github/) so a
+      GitHub Release mints a DOI. Add the DOI back into `CITATION.cff` and `.zenodo.json`
+      once known, bumping the version in lockstep.
+
+## Each release
+- [ ] Bump version in `pyproject.toml`, `.zenodo.json`, `CITATION.cff` (all equal).
+- [ ] Add a `CHANGELOG.md` entry.
+- [ ] (Optional) Run the `Publish` workflow via **workflow_dispatch** to push to TestPyPI
+      and verify the artifact installs from TestPyPI.
+- [ ] Tag `vX.Y.Z` and push the tag → the `pypi` job publishes to PyPI.
+- [ ] Create a GitHub Release for the tag → Zenodo archives it and mints a DOI.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -15,7 +15,8 @@ Infrastructure is in place; publishing is a deliberate manual action.
       once known, bumping the version in lockstep.
 
 ## Each release
-- [ ] Bump version in `pyproject.toml`, `.zenodo.json`, `CITATION.cff` (all equal).
+- [ ] Bump version in `pyproject.toml`, `.zenodo.json`, `CITATION.cff` (all equal),
+      and update the pinned version in `tests/test_smoke.py`.
 - [ ] Add a `CHANGELOG.md` entry.
 - [ ] (Optional) Run the `Publish` workflow via **workflow_dispatch** to push to TestPyPI
       and verify the artifact installs from TestPyPI.

--- a/docs/REPRODUCING.md
+++ b/docs/REPRODUCING.md
@@ -1,0 +1,31 @@
+# Reproducing the paper results
+
+## Environment
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,viz]"
+```
+
+## Full sweep
+
+```bash
+bash run.sh          # trains + evaluates all datasets into results/run-<date>/
+```
+This runs the preorder pipeline and the CLR / BR / CC / ECC baselines for each dataset
+in `run.sh`'s `DATASETS` list, writing per-fold CSVs and per-dataset logs.
+
+## Aggregate and analyze
+
+```bash
+python -m preorder4mlc.utils.summarize_metrics    # build summary tables
+python -m preorder4mlc.utils.statistical_tests    # significance tests
+python -m preorder4mlc.utils.plot_figures         # render figures
+```
+
+## Fast capsule (single dataset)
+
+```bash
+bash scripts/reproduce_capsule.sh results/         # CHD-49 only, CPU, quick
+```
+See also the project-level `REPRODUCE.md`.

--- a/docs/paper.yaml
+++ b/docs/paper.yaml
@@ -1,0 +1,30 @@
+# Experimental protocol for "Robust multi-label classification via preference learning"
+# (Machine Learning, Springer, 2026). Human/reviewer reference manifest; the CLI defaults
+# in preorder4mlc/config.py encode the operative values.
+
+model:
+  formulation: order-structure-learning   # MLC cast as (pre)order / preference learning
+  base_classifiers: [LogisticRegression, LightGBM, RandomForest]
+  pairwise: calibrated-label-ranking
+  inference: ilp                            # Bayes-optimal order via integer linear program
+  solver: HiGHS                             # highspy; CVXOPT fallback
+
+evaluation:
+  scheme: KFold
+  settings:
+    - robust-mlc-noisy-imbalanced
+    - partial-abstention
+  metrics: [F1, Jaccard, Hamming, abstention-rate]
+  noise_levels: [0.0, 0.1, 0.2, 0.3]        # cf. overleaf/figs/aggregate_*_noise0{0..3}
+
+datasets:
+  - chd_49
+  - emotions
+  - scene
+  - yeast
+  - water_quality
+  - gpositivepseaac
+  - plantpseaac
+  - viruspseaac
+  - humanpseaac
+  - enron

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,64 @@
 [build-system]
-requires = ["setuptools>=65"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "preorder4mlc"
 version = "1.0.0"
-description = "Pre-order based multi-label classification via pairwise classifiers and ILP search."
-requires-python = ">=3.10"
+description = "Robust multi-label classification via preference learning: pairwise classifiers and ILP-based Bayes-optimal order-structure prediction."
 readme = "README.md"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
+authors = [
+    { name = "Xuan-Truong Hoang", email = "hxtruong@jaist.ac.jp" },
+    { name = "Vu-Linh Nguyen", email = "vu-linh.nguyen@hds.utc.fr" },
+    { name = "Sébastien Destercke", email = "sebastien.destercke@hds.utc.fr" },
+    { name = "Cassio de Campos", email = "c.decampos@tue.nl" },
+    { name = "Van-Nam Huynh", email = "huynh@jaist.ac.jp" },
+]
+keywords = [
+    "multi-label classification",
+    "preference learning",
+    "order structures",
+    "integer linear programming",
+    "partial abstention",
+    "robustness",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "numpy>=1.26",
+    "scipy>=1.12",
+    "scikit-learn>=1.4",
+    "pandas>=2.0",
+    "joblib>=1.3",
+    "liac-arff>=2.5",
+    "lightgbm>=4.0",
+    "highspy>=1.7",
+    "cvxopt>=1.3",
+    "scikit-multilearn>=0.2",
+]
+
+[project.optional-dependencies]
+viz = [
+    "matplotlib>=3.8",
+    "seaborn>=0.13",
+    "openpyxl>=3.1",
+]
+dev = [
+    "pytest>=7",
+    "pytest-cov>=4",
+    "ruff>=0.4",
+    "build>=1.0",
+    "twine>=5.0",
+]
+
+[project.urls]
+Repository = "https://github.com/hxtruong6/pre-order-for-mlc"
 
 [tool.setuptools.packages.find]
 include = ["preorder4mlc*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,10 @@
+cvxopt==1.3.2
+highspy==1.14.0
+joblib==1.3.2
+liac-arff==2.5.0
+lightgbm==4.6.0
+numpy==2.3.0
+pandas==2.3.0
+scikit-learn==1.6.1
+scikit-multilearn==0.2.0
+scipy==1.15.3

--- a/scripts/reproduce_capsule.sh
+++ b/scripts/reproduce_capsule.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fast reproducibility capsule: trains + evaluates the preorder pipeline on the
+# smallest dataset (CHD-49) on CPU and writes per-fold CSVs to the output dir.
+# Usage: bash scripts/reproduce_capsule.sh [OUTPUT_DIR]
+set -euo pipefail
+
+OUT_DIR="${1:-results/capsule}"
+DATASET="chd_49"
+mkdir -p "${OUT_DIR}"
+
+echo "[capsule] training ${DATASET} -> ${OUT_DIR}"
+python scripts/train.py    --dataset "${DATASET}" --results_dir "${OUT_DIR}"
+echo "[capsule] evaluating ${DATASET}"
+python scripts/evaluate.py --dataset "${DATASET}" --results_dir "${OUT_DIR}"
+echo "[capsule] done. CSVs under ${OUT_DIR}"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,13 @@
+"""Smoke tests: the package imports and exposes its public API."""
+
+import importlib.metadata
+
+import preorder4mlc
+
+
+def test_package_imports():
+    assert preorder4mlc is not None
+
+
+def test_version_matches_metadata():
+    assert importlib.metadata.version("preorder4mlc") == "1.0.0"


### PR DESCRIPTION
## Summary

Adds release infrastructure to make `preorder4mlc` a publishable package, mirroring the conventions of the sibling `inference_probabilistic_mlc` project. The existing flat `preorder4mlc/` package layout is unchanged — this only adds packaging, CI/CD, docs, and a reproducibility capsule **around** it. No package is published by this PR.

- **Packaging metadata:** full `[project]` metadata in `pyproject.toml` (authors, deps, URLs, classifiers, version `1.0.0`); `.zenodo.json` deposition metadata; `CITATION.cff` reordered to first-author + ORCID; `MANIFEST.in` (internal planning docs pruned from the sdist).
- **Tests:** `tests/` with import + version smoke tests (the package previously had no test suite).
- **CI/CD:** `.github/workflows/ci.yml` (ruff + pytest on 3.10/3.12, 3-file version-consistency gate) and `publish.yml` (build → TestPyPI on dispatch / PyPI on `v*` tag via OIDC trusted publishing).
- **Reproducibility:** `requirements-core.txt`, `scripts/reproduce_capsule.sh` (CHD-49, CPU), and a `Dockerfile`.
- **Docs:** `docs/{CONVENTIONS,REPRODUCING,EXTENDING,RELEASE_CHECKLIST}.md`, `docs/paper.yaml`, plus `CHANGELOG.md`, `CONTRIBUTING.md`, and a `Makefile` (`lint`/`test`/`build`/`reproduce`).

Version is pinned at `1.0.0` across `pyproject.toml`, `.zenodo.json`, and `CITATION.cff`; CI fails if they diverge.

## Test plan

- [x] `python -m build` produces a valid sdist + wheel; `python -m twine check dist/*` PASSED.
- [x] sdist excludes internal planning docs (`docs/superpowers/` pruned — verified in tarball).
- [x] `ruff check preorder4mlc tests` clean.
- [x] `pytest tests/ -q` passes.
- [x] Version-consistency check passes (all three files at `1.0.0`).
- [x] `make lint` / `make test` / `make build` succeed.
- [x] Reproducibility capsule verified end-to-end: `scripts/reproduce_capsule.sh` trained CHD-49 and produced evaluation CSVs.
- [ ] CI runs green on GitHub Actions (verify after merge / on this PR).

## Not in scope (deliberate)

- No actual publish: no PyPI/TestPyPI upload, no Zenodo DOI, no release tag. See `docs/RELEASE_CHECKLIST.md` for the manual steps (reserve PyPI name, configure GitHub environments + OIDC, connect Zenodo, tag `v1.0.0`).
- No migration to a `src/` layout.